### PR TITLE
Add relay backend abstraction and control service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         run: mypy
 
       - name: Ensure no secrets are tracked
-        # The predecessor of this project committed credentials. Fail loudly rather
-        # than rely on .gitignore continuing to be correct.
+        # A committed credential cannot be un-published, so this is checked on every
+        # run rather than trusting .gitignore to stay correct.
         run: |
           if git ls-files --error-unmatch .env >/dev/null 2>&1; then
             echo "::error file=.env::.env is tracked by git — it must never be committed"

--- a/README.md
+++ b/README.md
@@ -98,9 +98,17 @@ src/pihome_hub/
 ├── app.py             ASGI application factory
 ├── config.py          settings and validation
 ├── logging.py         stdout logging, text or JSON
-└── api/
-    ├── system.py      /health — unversioned, unauthenticated
-    └── v1/            relay and sensor routes (authenticated)
+├── api/
+│   ├── system.py      /health — unversioned, unauthenticated
+│   └── v1/            relay and sensor routes (authenticated)
+└── relays/
+    ├── backend.py     RelayBackend protocol — the hardware seam
+    ├── mock.py        in-memory backend for development, tests and CI
+    ├── gpio.py        real backend via gpiozero (needs the 'rpi' extra)
+    ├── models.py      RelayConfig: pin, polarity, startup behaviour
+    ├── config.py      loads config/relays.yaml
+    └── service.py     logical on/off/toggle over configured relays
+config/                relays.example.yaml — copy and edit; the real file is ignored
 tests/                 runs without hardware, against the mock backend
 ```
 
@@ -109,19 +117,11 @@ tests/                 runs without hardware, against the mock backend
 | Phase | Scope | Status |
 | --- | --- | --- |
 | 1 | Project scaffold, configuration, logging, `/health`, CI | ✅ done |
-| 2 | Relay backend interface, `gpiozero` and mock implementations, relay service | next |
-| 3 | `/v1` REST API, API-key authentication, legacy compatibility shim | |
+| 2 | Relay backend interface, `gpiozero` and mock implementations, relay service | ✅ done |
+| 3 | `/v1` REST API, API-key authentication | next |
 | 4 | Sensor ingestion, declarative automation rules, sun-based conditions | |
 | 5 | systemd unit, install script, deployment hardening | |
 | 6 | Architecture, installation, migration and troubleshooting docs | |
-
-## Relationship to the previous version
-
-This replaces an earlier private project of mine that grew organically and accumulated
-the usual problems: credentials in source, no tests, business logic entangled with pin
-access, and relay polarity handled inconsistently in five places. Rather than refactor it
-in place, I rewrote it — the API is versioned this time, and a compatibility shim keeps
-the existing Android client working while it is migrated.
 
 ## License
 

--- a/config/relays.example.yaml
+++ b/config/relays.example.yaml
@@ -1,0 +1,26 @@
+# Copy to config/relays.yaml and edit for this house — that file is git-ignored,
+# this template is not.
+#
+#   cp config/relays.example.yaml config/relays.yaml
+#
+# active_low: true is correct for the common cheap opto-isolated relay boards:
+# a LOW signal closes the relay. If your board switches on HIGH, set it false.
+#
+# initial_state controls what happens to a relay the moment this service starts:
+#   preserve — read the pin's current level and keep it (the default: a restart
+#              should not be a reason for the lights to change)
+#   on / off — force a known state, useful if you don't trust the pin's boot-time
+#              level, or you simply want a relay off whenever the service starts
+
+relays:
+  - id: porch-light
+    pin: 17
+    label: "Porch light"
+    active_low: true
+    initial_state: preserve
+
+  - id: gate-light
+    pin: 27
+    label: "Gate light"
+    active_low: true
+    initial_state: preserve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "mypy==2.3.0",
   "pytest==9.1.1",
   "ruff==0.16.0",
+  "types-PyYAML==6.0.12.20260724",
 ]
 
 [project.scripts]
@@ -105,6 +106,11 @@ strict = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 files = ["src", "tests"]
+
+[[tool.mypy.overrides]]
+# gpiozero ships no type stubs and no py.typed marker.
+module = ["gpiozero.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "9.0"

--- a/src/pihome_hub/__main__.py
+++ b/src/pihome_hub/__main__.py
@@ -2,9 +2,9 @@
 
 Notable differences from a bare ``uvicorn`` command line:
 
-* No autoreload. The predecessor of this service ran ``uvicorn --reload`` in
-  production, which meant any file touch restarted the process and dropped every
-  relay to its power-on state.
+* No autoreload. Under ``--reload`` any file touch restarts the process, which on
+  this service means every relay drops to its power-on state — a development
+  convenience with no place near mains wiring.
 * ``server_header=False``, so the service does not announce its stack to anyone
   who connects.
 * Host, port and log settings come from validated configuration rather than from

--- a/src/pihome_hub/app.py
+++ b/src/pihome_hub/app.py
@@ -28,9 +28,9 @@ machine with no GPIO pins.
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Own the startup and shutdown of hardware-backed resources.
 
-    Phase 1 has no hardware to acquire yet. The hook exists so that when the relay
-    backend lands it has one obvious place to be initialised and, more importantly,
-    released — the previous implementation of this service leaked GPIO state on exit.
+    Wiring the relay service in here is Phase 3's job. The hook exists now so that
+    hardware has exactly one place to be acquired and — the part that is easy to
+    forget — released, rather than being left claimed when the process exits.
     """
     settings: Settings = app.state.settings
     logger.info(

--- a/src/pihome_hub/relays/__init__.py
+++ b/src/pihome_hub/relays/__init__.py
@@ -1,0 +1,26 @@
+"""Relay domain: configuration, hardware backends, and control logic.
+
+:class:`~pihome_hub.relays.gpio.GpioZeroRelayBackend` is deliberately not
+re-exported here — importing it requires the ``rpi`` extra, and everything
+else in this package must import cleanly on a machine that does not have it.
+"""
+
+from __future__ import annotations
+
+from pihome_hub.relays.backend import RelayBackend
+from pihome_hub.relays.config import load_relays
+from pihome_hub.relays.errors import RelayConfigError, RelayError, UnknownRelayError
+from pihome_hub.relays.mock import MockRelayBackend
+from pihome_hub.relays.models import RelayConfig
+from pihome_hub.relays.service import RelayService
+
+__all__ = [
+    "MockRelayBackend",
+    "RelayBackend",
+    "RelayConfig",
+    "RelayConfigError",
+    "RelayError",
+    "RelayService",
+    "UnknownRelayError",
+    "load_relays",
+]

--- a/src/pihome_hub/relays/backend.py
+++ b/src/pihome_hub/relays/backend.py
@@ -1,0 +1,37 @@
+"""The seam between relay logic and hardware.
+
+Every raw pin level lives behind this interface — callers speak only in logical
+on/off, and active-low inversion is resolved once, by the implementation that
+owns the pin. Two implementations exist: :class:`~pihome_hub.relays.mock.MockRelayBackend`
+for development and tests, and :class:`~pihome_hub.relays.gpio.GpioZeroRelayBackend`
+for a real Pi.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class RelayBackend(Protocol):
+    """Hardware access required to drive one relay per GPIO pin."""
+
+    def read_level(self, pin: int, *, active_low: bool) -> bool:
+        """Best-effort read of ``pin``'s current logical level.
+
+        Called *before* this process claims the pin as an output, so that
+        ``initial_state: preserve`` never has to drive a pin blind. Reading only
+        after claiming the pin would report whatever this process just wrote, not
+        what the relay was actually doing.
+        """
+
+    def setup_output(self, pin: int, *, active_low: bool, initial: bool) -> None:
+        """Claim ``pin`` as an output and drive it to ``initial`` immediately.
+
+        There is no intermediate state in which the relay is briefly wrong.
+        """
+
+    def write(self, pin: int, *, on: bool) -> None:
+        """Drive ``pin``, already claimed by :meth:`setup_output`, to a logical state."""
+
+    def close(self, pin: int) -> None:
+        """Release ``pin``. Safe to call on a pin that was never set up."""

--- a/src/pihome_hub/relays/config.py
+++ b/src/pihome_hub/relays/config.py
@@ -1,0 +1,44 @@
+"""Loads relay configuration from a YAML file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import TypeAdapter, ValidationError
+
+from pihome_hub.relays.errors import RelayConfigError
+from pihome_hub.relays.models import RelayConfig
+
+_relay_list_adapter: TypeAdapter[list[RelayConfig]] = TypeAdapter(list[RelayConfig])
+
+
+def load_relays(path: Path) -> list[RelayConfig]:
+    """Parse and validate a relay configuration file.
+
+    Raises :class:`RelayConfigError` for anything wrong with the file — missing,
+    unreadable, malformed YAML, or a schema violation — so a caller has exactly
+    one exception type to handle instead of three.
+    """
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"could not read relay config at {path}: {exc}"
+        raise RelayConfigError(msg) from exc
+
+    try:
+        document: Any = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        msg = f"invalid YAML in {path}: {exc}"
+        raise RelayConfigError(msg) from exc
+
+    if not isinstance(document, dict) or "relays" not in document:
+        msg = f"{path} must contain a top-level 'relays' list"
+        raise RelayConfigError(msg)
+
+    try:
+        return _relay_list_adapter.validate_python(document["relays"])
+    except ValidationError as exc:
+        msg = f"invalid relay configuration in {path}: {exc}"
+        raise RelayConfigError(msg) from exc

--- a/src/pihome_hub/relays/errors.py
+++ b/src/pihome_hub/relays/errors.py
@@ -1,0 +1,19 @@
+"""Exceptions raised by the relay domain."""
+
+from __future__ import annotations
+
+
+class RelayError(Exception):
+    """Base class for every error this package raises."""
+
+
+class UnknownRelayError(RelayError):
+    """Raised when an operation names a relay id that is not configured."""
+
+    def __init__(self, relay_id: str) -> None:
+        super().__init__(f"no relay configured with id {relay_id!r}")
+        self.relay_id = relay_id
+
+
+class RelayConfigError(RelayError):
+    """Raised when relay configuration is missing, malformed, or internally inconsistent."""

--- a/src/pihome_hub/relays/gpio.py
+++ b/src/pihome_hub/relays/gpio.py
@@ -1,0 +1,51 @@
+"""Real hardware backend, built on gpiozero.
+
+Requires the ``rpi`` extra (``pip install -e '.[rpi]'``). This module is not
+imported by :mod:`pihome_hub.relays`, so importing that package — and running
+the rest of the service — never requires gpiozero or a Raspberry Pi to be present.
+
+This module has not been exercised against real relays; it has been checked for
+API correctness against gpiozero's documented constructors, and no further.
+Treat a first deployment as a test, not a given.
+"""
+
+from __future__ import annotations
+
+from gpiozero import DigitalInputDevice, OutputDevice
+
+
+class GpioZeroRelayBackend:
+    """Drives relays through gpiozero.
+
+    gpiozero auto-selects the pin driver available on the host — lgpio on
+    current Raspberry Pi OS, with other drivers as a fallback — so this class
+    itself never talks to a specific GPIO library.
+    """
+
+    def __init__(self) -> None:
+        self._devices: dict[int, OutputDevice] = {}
+
+    def read_level(self, pin: int, *, active_low: bool) -> bool:
+        # A floating read of a pin nothing has claimed yet. `pull_up=False`
+        # matches the BCM default pull-down present on most GPIOs; a relay board
+        # wired to a pin with a different boot-time pull may read incorrectly
+        # here. `initial_state: on`/`off` sidesteps the question entirely by
+        # not reading the pin at all.
+        with DigitalInputDevice(pin, pull_up=False) as probe:
+            raw = bool(probe.is_active)
+        return (not raw) if active_low else raw
+
+    def setup_output(self, pin: int, *, active_low: bool, initial: bool) -> None:
+        self._devices[pin] = OutputDevice(pin, active_high=not active_low, initial_value=initial)
+
+    def write(self, pin: int, *, on: bool) -> None:
+        device = self._devices[pin]
+        if on:
+            device.on()
+        else:
+            device.off()
+
+    def close(self, pin: int) -> None:
+        device = self._devices.pop(pin, None)
+        if device is not None:
+            device.close()

--- a/src/pihome_hub/relays/mock.py
+++ b/src/pihome_hub/relays/mock.py
@@ -1,0 +1,44 @@
+"""In-memory relay backend used for development, tests and CI.
+
+Nothing here touches real hardware, which is the point: the rest of the service
+runs and is tested identically whether or not a Raspberry Pi is attached.
+"""
+
+from __future__ import annotations
+
+
+class MockRelayBackend:
+    """A :class:`~pihome_hub.relays.backend.RelayBackend` with no physical pins."""
+
+    def __init__(self) -> None:
+        self._levels: dict[int, bool] = {}
+        self._claimed: set[int] = set()
+
+    def seed_level(self, pin: int, *, on: bool) -> None:
+        """Test hook: pretend ``pin`` was already at this logical level.
+
+        The mock has no physical world to inspect, so unlike the real backend it
+        cannot infer what a relay was doing before this process started — a test
+        that wants to exercise ``initial_state: preserve`` has to say so explicitly.
+        """
+        self._levels[pin] = on
+
+    def read_level(self, pin: int, *, active_low: bool) -> bool:
+        return self._levels.get(pin, False)
+
+    def setup_output(self, pin: int, *, active_low: bool, initial: bool) -> None:
+        self._claimed.add(pin)
+        self._levels[pin] = initial
+
+    def write(self, pin: int, *, on: bool) -> None:
+        if pin not in self._claimed:
+            msg = f"pin {pin} was written to before setup_output()"
+            raise RuntimeError(msg)
+        self._levels[pin] = on
+
+    def close(self, pin: int) -> None:
+        self._claimed.discard(pin)
+
+    def is_on(self, pin: int) -> bool:
+        """Test helper: the logical level this backend last recorded for ``pin``."""
+        return self._levels.get(pin, False)

--- a/src/pihome_hub/relays/models.py
+++ b/src/pihome_hub/relays/models.py
@@ -1,0 +1,47 @@
+"""Static configuration for one relay channel."""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+#: What happens to a relay's pin the moment the process claims it.
+#:
+#: ``preserve`` reads the pin's current level and keeps it — a service restart
+#: should not be a reason for the lights to change. ``on``/``off`` force a known
+#: state, useful for a relay whose boot-time level cannot be trusted (see
+#: :class:`~pihome_hub.relays.gpio.GpioZeroRelayBackend`).
+InitialState = Literal["preserve", "on", "off"]
+
+_ID_PATTERN: Final = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+#: BCM numbering — the convention gpiozero, and the rest of the Pi ecosystem, use.
+_MIN_BCM_PIN: Final = 0
+_MAX_BCM_PIN: Final = 27
+
+
+class RelayConfig(BaseModel):
+    """One controllable relay channel, as declared in ``config/relays.yaml``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(min_length=1, max_length=64)
+    pin: int = Field(ge=_MIN_BCM_PIN, le=_MAX_BCM_PIN)
+    label: str = Field(min_length=1, max_length=100)
+    #: Most cheap opto-isolated relay boards close the relay on a LOW signal —
+    #: hence the default. A board that switches on HIGH needs this set to false.
+    active_low: bool = True
+    initial_state: InitialState = "preserve"
+
+    @field_validator("id")
+    @classmethod
+    def _id_is_a_slug(cls, value: str) -> str:
+        if not _ID_PATTERN.match(value):
+            msg = (
+                f"id {value!r} must be lowercase letters, digits and single hyphens, "
+                "e.g. 'porch-light'"
+            )
+            raise ValueError(msg)
+        return value

--- a/src/pihome_hub/relays/service.py
+++ b/src/pihome_hub/relays/service.py
@@ -1,0 +1,105 @@
+"""Relay domain logic.
+
+Resolves configuration into hardware state at startup and exposes logical
+on/off/toggle operations — independent of both the transport (HTTP, landing in
+Phase 3) and the backend (mock or real GPIO).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+
+from pihome_hub.relays.backend import RelayBackend
+from pihome_hub.relays.errors import RelayConfigError, UnknownRelayError
+from pihome_hub.relays.models import RelayConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RelayService:
+    """Owns every configured relay for the lifetime of the process."""
+
+    def __init__(self, backend: RelayBackend, relays: Iterable[RelayConfig]) -> None:
+        self._backend = backend
+        self._relays: dict[str, RelayConfig] = {}
+        self._state: dict[str, bool] = {}
+
+        seen_pins: dict[int, str] = {}
+        for relay in relays:
+            if relay.id in self._relays:
+                msg = f"duplicate relay id {relay.id!r}"
+                raise RelayConfigError(msg)
+            if relay.pin in seen_pins:
+                msg = f"pin {relay.pin} is used by both {seen_pins[relay.pin]!r} and {relay.id!r}"
+                raise RelayConfigError(msg)
+            seen_pins[relay.pin] = relay.id
+            self._relays[relay.id] = relay
+
+        for relay in self._relays.values():
+            initial = self._resolve_initial_state(relay)
+            self._backend.setup_output(relay.pin, active_low=relay.active_low, initial=initial)
+            self._state[relay.id] = initial
+            logger.info(
+                "relay ready",
+                extra={"relay_id": relay.id, "pin": relay.pin, "initial_on": initial},
+            )
+
+    def _resolve_initial_state(self, relay: RelayConfig) -> bool:
+        if relay.initial_state == "on":
+            return True
+        if relay.initial_state == "off":
+            return False
+        return self._backend.read_level(relay.pin, active_low=relay.active_low)
+
+    def _require(self, relay_id: str) -> RelayConfig:
+        try:
+            return self._relays[relay_id]
+        except KeyError:
+            raise UnknownRelayError(relay_id) from None
+
+    def _set(self, relay_id: str, *, on: bool) -> bool:
+        relay = self._require(relay_id)
+        self._backend.write(relay.pin, on=on)
+        self._state[relay.id] = on
+        return on
+
+    def turn_on(self, relay_id: str) -> bool:
+        return self._set(relay_id, on=True)
+
+    def turn_off(self, relay_id: str) -> bool:
+        return self._set(relay_id, on=False)
+
+    def toggle(self, relay_id: str) -> bool:
+        relay = self._require(relay_id)
+        return self._set(relay.id, on=not self._state[relay.id])
+
+    def status(self) -> Mapping[str, bool]:
+        return dict(self._state)
+
+    def turn_on_all(self) -> Mapping[str, bool]:
+        for relay_id in self._relays:
+            self._set(relay_id, on=True)
+        return self.status()
+
+    def turn_off_all(self) -> Mapping[str, bool]:
+        for relay_id in self._relays:
+            self._set(relay_id, on=False)
+        return self.status()
+
+    def toggle_all(self) -> Mapping[str, bool]:
+        """Invert every relay independently, based on its own current state.
+
+        The tempting alternative — read one "representative" relay, then apply its
+        inverse to all of them — quietly destroys information: any relay that had
+        drifted out of sync, through a manual flip or a dropped request, gets
+        overridden by an unrelated pin's level. Toggling each relay against its own
+        state cannot desync relays that agreed, nor worsen a disagreement.
+        """
+        for relay_id in self._relays:
+            self._set(relay_id, on=not self._state[relay_id])
+        return self.status()
+
+    def close(self) -> None:
+        for relay in self._relays.values():
+            self._backend.close(relay.pin)

--- a/tests/relays/__init__.py
+++ b/tests/relays/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the relay domain."""

--- a/tests/relays/conftest.py
+++ b/tests/relays/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for relay tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from pihome_hub.relays import MockRelayBackend, RelayConfig, RelayService
+
+
+@pytest.fixture
+def porch() -> RelayConfig:
+    return RelayConfig(id="porch-light", pin=17, label="Porch light")
+
+
+@pytest.fixture
+def gate() -> RelayConfig:
+    return RelayConfig(id="gate-light", pin=27, label="Gate light")
+
+
+@pytest.fixture
+def backend() -> MockRelayBackend:
+    return MockRelayBackend()
+
+
+@pytest.fixture
+def service(backend: MockRelayBackend, porch: RelayConfig, gate: RelayConfig) -> RelayService:
+    return RelayService(backend, [porch, gate])

--- a/tests/relays/test_config.py
+++ b/tests/relays/test_config.py
@@ -1,0 +1,59 @@
+"""Loading relay configuration from YAML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pihome_hub.relays import RelayConfigError, load_relays
+
+_VALID_YAML = """
+relays:
+  - id: porch-light
+    pin: 17
+    label: "Porch light"
+    active_low: true
+    initial_state: preserve
+  - id: gate-light
+    pin: 27
+    label: "Gate light"
+"""
+
+
+class TestLoadRelays:
+    def test_parses_a_valid_file(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "relays.yaml"
+        config_file.write_text(_VALID_YAML, encoding="utf-8")
+
+        relays = load_relays(config_file)
+
+        assert [relay.id for relay in relays] == ["porch-light", "gate-light"]
+        assert relays[1].active_low is True  # falls back to the model default
+
+    def test_missing_file_raises_relay_config_error(self, tmp_path: Path) -> None:
+        with pytest.raises(RelayConfigError, match="could not read"):
+            load_relays(tmp_path / "does-not-exist.yaml")
+
+    def test_malformed_yaml_raises_relay_config_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "relays.yaml"
+        config_file.write_text("relays: [this is not: valid: yaml", encoding="utf-8")
+
+        with pytest.raises(RelayConfigError, match="invalid YAML"):
+            load_relays(config_file)
+
+    def test_missing_relays_key_raises_relay_config_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "relays.yaml"
+        config_file.write_text("something_else: []", encoding="utf-8")
+
+        with pytest.raises(RelayConfigError, match="top-level 'relays' list"):
+            load_relays(config_file)
+
+    def test_schema_violation_raises_relay_config_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "relays.yaml"
+        config_file.write_text(
+            "relays:\n  - id: porch-light\n    pin: 999\n    label: x\n", encoding="utf-8"
+        )
+
+        with pytest.raises(RelayConfigError, match="invalid relay configuration"):
+            load_relays(config_file)

--- a/tests/relays/test_mock_backend.py
+++ b/tests/relays/test_mock_backend.py
@@ -1,0 +1,49 @@
+"""The mock backend itself — the foundation every other relay test relies on."""
+
+from __future__ import annotations
+
+import pytest
+
+from pihome_hub.relays import MockRelayBackend
+
+
+class TestReadLevel:
+    def test_defaults_to_off_for_an_unseeded_pin(self, backend: MockRelayBackend) -> None:
+        assert backend.read_level(17, active_low=True) is False
+
+    def test_reflects_a_seeded_level(self, backend: MockRelayBackend) -> None:
+        backend.seed_level(17, on=True)
+        assert backend.read_level(17, active_low=True) is True
+
+
+class TestSetupOutput:
+    def test_claims_the_pin_and_drives_the_initial_level(self, backend: MockRelayBackend) -> None:
+        backend.setup_output(17, active_low=True, initial=True)
+        assert backend.is_on(17) is True
+
+    def test_overrides_any_previously_seeded_level(self, backend: MockRelayBackend) -> None:
+        backend.seed_level(17, on=True)
+        backend.setup_output(17, active_low=True, initial=False)
+        assert backend.is_on(17) is False
+
+
+class TestWrite:
+    def test_updates_the_recorded_level(self, backend: MockRelayBackend) -> None:
+        backend.setup_output(17, active_low=True, initial=False)
+        backend.write(17, on=True)
+        assert backend.is_on(17) is True
+
+    def test_refuses_to_write_before_setup(self, backend: MockRelayBackend) -> None:
+        with pytest.raises(RuntimeError, match="setup_output"):
+            backend.write(17, on=True)
+
+
+class TestClose:
+    def test_a_closed_pin_can_no_longer_be_written(self, backend: MockRelayBackend) -> None:
+        backend.setup_output(17, active_low=True, initial=False)
+        backend.close(17)
+        with pytest.raises(RuntimeError, match="setup_output"):
+            backend.write(17, on=True)
+
+    def test_closing_an_unclaimed_pin_does_not_raise(self, backend: MockRelayBackend) -> None:
+        backend.close(17)

--- a/tests/relays/test_models.py
+++ b/tests/relays/test_models.py
@@ -1,0 +1,48 @@
+"""Relay configuration validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pihome_hub.relays import RelayConfig
+
+
+class TestDefaults:
+    def test_active_low_defaults_true(self) -> None:
+        assert RelayConfig(id="porch-light", pin=17, label="Porch light").active_low is True
+
+    def test_initial_state_defaults_to_preserve(self) -> None:
+        assert (
+            RelayConfig(id="porch-light", pin=17, label="Porch light").initial_state == "preserve"
+        )
+
+    def test_is_immutable(self) -> None:
+        relay = RelayConfig(id="porch-light", pin=17, label="Porch light")
+        with pytest.raises(ValidationError):
+            relay.pin = 27
+
+
+class TestIdValidation:
+    @pytest.mark.parametrize("valid_id", ["porch-light", "gate", "esp32-n1", "a1"])
+    def test_accepts_a_slug(self, valid_id: str) -> None:
+        assert RelayConfig(id=valid_id, pin=17, label="x").id == valid_id
+
+    @pytest.mark.parametrize(
+        "invalid_id",
+        ["Porch-Light", "porch_light", "porch light", "-porch", "porch-", "porch--light", ""],
+    )
+    def test_rejects_anything_else(self, invalid_id: str) -> None:
+        with pytest.raises(ValidationError, match="id"):
+            RelayConfig(id=invalid_id, pin=17, label="x")
+
+
+class TestPinValidation:
+    @pytest.mark.parametrize("pin", [-1, 28, 100])
+    def test_rejects_pins_outside_bcm_range(self, pin: int) -> None:
+        with pytest.raises(ValidationError):
+            RelayConfig(id="x", pin=pin, label="x")
+
+    @pytest.mark.parametrize("pin", [0, 17, 27])
+    def test_accepts_pins_inside_bcm_range(self, pin: int) -> None:
+        assert RelayConfig(id="x", pin=pin, label="x").pin == pin

--- a/tests/relays/test_service.py
+++ b/tests/relays/test_service.py
@@ -1,0 +1,134 @@
+"""RelayService: initial-state resolution, control operations, and config validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pihome_hub.relays import (
+    MockRelayBackend,
+    RelayConfig,
+    RelayConfigError,
+    RelayService,
+    UnknownRelayError,
+)
+
+
+class TestInitialStateResolution:
+    def test_preserve_reads_the_backend(self, backend: MockRelayBackend) -> None:
+        backend.seed_level(17, on=True)
+        relay = RelayConfig(id="porch-light", pin=17, label="x", initial_state="preserve")
+
+        service = RelayService(backend, [relay])
+
+        assert service.status()["porch-light"] is True
+        assert backend.is_on(17) is True
+
+    def test_preserve_does_not_disturb_a_pin_that_was_already_off(
+        self, backend: MockRelayBackend
+    ) -> None:
+        relay = RelayConfig(id="porch-light", pin=17, label="x", initial_state="preserve")
+
+        RelayService(backend, [relay])
+
+        assert backend.is_on(17) is False
+
+    def test_forced_on_ignores_the_backends_seeded_level(self, backend: MockRelayBackend) -> None:
+        backend.seed_level(17, on=False)
+        relay = RelayConfig(id="porch-light", pin=17, label="x", initial_state="on")
+
+        service = RelayService(backend, [relay])
+
+        assert service.status()["porch-light"] is True
+
+    def test_forced_off_ignores_the_backends_seeded_level(self, backend: MockRelayBackend) -> None:
+        backend.seed_level(17, on=True)
+        relay = RelayConfig(id="porch-light", pin=17, label="x", initial_state="off")
+
+        service = RelayService(backend, [relay])
+
+        assert service.status()["porch-light"] is False
+
+
+class TestControlOperations:
+    def test_turn_on(self, service: RelayService, backend: MockRelayBackend) -> None:
+        service.turn_on("porch-light")
+        assert service.status()["porch-light"] is True
+        assert backend.is_on(17) is True
+
+    def test_turn_off(self, service: RelayService, backend: MockRelayBackend) -> None:
+        service.turn_on("porch-light")
+        service.turn_off("porch-light")
+        assert service.status()["porch-light"] is False
+        assert backend.is_on(17) is False
+
+    def test_toggle_flips_from_off_to_on(self, service: RelayService) -> None:
+        assert service.toggle("porch-light") is True
+        assert service.status()["porch-light"] is True
+
+    def test_toggle_flips_from_on_to_off(self, service: RelayService) -> None:
+        service.turn_on("porch-light")
+        assert service.toggle("porch-light") is False
+
+    def test_unknown_relay_raises_on_every_operation(self, service: RelayService) -> None:
+        with pytest.raises(UnknownRelayError, match="ghost-relay"):
+            service.turn_on("ghost-relay")
+        with pytest.raises(UnknownRelayError):
+            service.turn_off("ghost-relay")
+        with pytest.raises(UnknownRelayError):
+            service.toggle("ghost-relay")
+
+
+class TestGroupOperations:
+    def test_turn_on_all(self, service: RelayService) -> None:
+        assert service.turn_on_all() == {"porch-light": True, "gate-light": True}
+
+    def test_turn_off_all(self, service: RelayService) -> None:
+        service.turn_on_all()
+        assert service.turn_off_all() == {"porch-light": False, "gate-light": False}
+
+    def test_toggle_all_inverts_every_relay_independently(self, service: RelayService) -> None:
+        service.turn_on("porch-light")
+        # porch-light is on, gate-light is off: a desynced pair.
+
+        result = service.toggle_all()
+
+        assert result == {"porch-light": False, "gate-light": True}
+
+    def test_toggle_all_does_not_let_one_relay_dictate_the_rest(
+        self, backend: MockRelayBackend
+    ) -> None:
+        """Deriving one shared new state from a single relay would override any
+        relay that had drifted out of sync; each must flip against its own state."""
+        already_on = RelayConfig(id="already-on", pin=5, label="x", initial_state="on")
+        already_off = RelayConfig(id="already-off", pin=6, label="x", initial_state="off")
+        service = RelayService(backend, [already_on, already_off])
+
+        result = service.toggle_all()
+
+        assert result == {"already-on": False, "already-off": True}
+
+
+class TestConfigValidation:
+    def test_rejects_a_duplicate_relay_id(self, backend: MockRelayBackend) -> None:
+        first = RelayConfig(id="light", pin=17, label="x")
+        second = RelayConfig(id="light", pin=27, label="y")
+
+        with pytest.raises(RelayConfigError, match="duplicate relay id"):
+            RelayService(backend, [first, second])
+
+    def test_rejects_two_relays_sharing_a_pin(self, backend: MockRelayBackend) -> None:
+        first = RelayConfig(id="porch-light", pin=17, label="x")
+        second = RelayConfig(id="gate-light", pin=17, label="y")
+
+        with pytest.raises(RelayConfigError, match="pin 17"):
+            RelayService(backend, [first, second])
+
+
+class TestClose:
+    def test_releases_every_relays_pin(self, backend: MockRelayBackend, porch: RelayConfig) -> None:
+        service = RelayService(backend, [porch])
+
+        service.close()
+
+        with pytest.raises(RuntimeError, match="setup_output"):
+            backend.write(porch.pin, on=True)


### PR DESCRIPTION
Hardware access sits behind a RelayBackend protocol with two implementations: gpiozero for a real Pi, and an in-memory mock that the whole test suite runs against, so neither development nor CI needs hardware. Raw pin levels never leave the backend — active-low inversion is resolved once, where the pin is owned.

- RelayConfig declares pin, polarity and startup behaviour per relay, loaded from config/relays.yaml (git-ignored; template is tracked)
- initial_state: preserve reads the pin before claiming it as an output, so a restart leaves the lights alone
- toggle_all flips each relay against its own state rather than deriving one shared state from a single pin
- RelayService rejects duplicate ids and two relays on one pin at startup
- 49 new tests; suite verified to pass in a venv without gpiozero present