### PR TITLE
Expose automation rules over HTTP

### DIFF
--- a/src/pihome_hub/api/v1/automation.py
+++ b/src/pihome_hub/api/v1/automation.py
@@ -1,0 +1,29 @@
+"""Automation rule read-back.
+
+Read-only: rules are declared in a YAML file that describes a house, and editing
+that over HTTP is a separate decision from being able to see it.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from pihome_hub.api.v1.schemas import AutomationRuleCollection
+from pihome_hub.automation import AutomationEngine
+from pihome_hub.security import RelayKeyRequired
+
+router = APIRouter(
+    prefix="/v1/automation",
+    tags=["automation"],
+    dependencies=[RelayKeyRequired],
+    responses={
+        401: {"description": "Missing or invalid API key"},
+        429: {"description": "Too many failed authentication attempts"},
+    },
+)
+
+
+@router.get("/rules", summary="List every configured automation rule")
+def list_rules(request: Request) -> AutomationRuleCollection:
+    engine: AutomationEngine = request.app.state.automation
+    return AutomationRuleCollection(rules=list(engine.configured))

--- a/src/pihome_hub/api/v1/schemas.py
+++ b/src/pihome_hub/api/v1/schemas.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from pihome_hub.automation import AutomationRule
 from pihome_hub.sensors import DeviceSnapshot
 
 
@@ -48,3 +49,15 @@ class SensorCollection(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     sensors: list[DeviceSnapshot]
+
+
+class AutomationRuleCollection(BaseModel):
+    """Every configured automation rule.
+
+    Carries no ``location``: the coordinates that block belongs to identify a home,
+    and nothing here needs them.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rules: list[AutomationRule]

--- a/src/pihome_hub/app.py
+++ b/src/pihome_hub/app.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 
 from pihome_hub import __version__
 from pihome_hub.api.system import router as system_router
+from pihome_hub.api.v1.automation import router as automation_router
 from pihome_hub.api.v1.relays import router as relays_router
 from pihome_hub.api.v1.sensors import ingest_router, read_router
 from pihome_hub.automation import AutomationEngine, SunClock, load_automation
@@ -193,5 +194,6 @@ def create_app(
     app.include_router(relays_router)
     app.include_router(read_router)
     app.include_router(ingest_router)
+    app.include_router(automation_router)
 
     return app

--- a/src/pihome_hub/automation/engine.py
+++ b/src/pihome_hub/automation/engine.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 
 from pihome_hub.automation.errors import AutomationConfigError
 from pihome_hub.automation.models import AutomationRule
@@ -36,7 +36,10 @@ class AutomationEngine:
     ) -> None:
         self._relays = relays
         self._sun = sun
-        self._rules = [rule for rule in rules if rule.enabled]
+        #: Every rule as configured. Kept so the API can report a disabled rule as
+        #: disabled rather than omitting it.
+        self._configured = list(rules)
+        self._rules = [rule for rule in self._configured if rule.enabled]
         #: One pending revert per relay, keyed by relay id — a second rule acting on
         #: the same relay replaces the first one's timer rather than racing it.
         self._holds: dict[str, asyncio.Task[None]] = {}
@@ -68,6 +71,11 @@ class AutomationEngine:
     @property
     def rules(self) -> Mapping[str, AutomationRule]:
         return {rule.id: rule for rule in self._rules}
+
+    @property
+    def configured(self) -> Sequence[AutomationRule]:
+        """Every rule, enabled or not, in configuration order."""
+        return tuple(self._configured)
 
     @property
     def pending_holds(self) -> frozenset[str]:

--- a/tests/test_api_automation.py
+++ b/tests/test_api_automation.py
@@ -1,0 +1,106 @@
+"""The /v1/automation surface."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pihome_hub.app import create_app
+from tests.conftest import RELAY_HEADERS, SENSOR_HEADERS, build_relay_service, build_settings
+
+SENSORS_YAML = """
+devices:
+  - id: porch-motion
+    label: "Porch motion"
+    stale_after_seconds: 300
+"""
+
+AUTOMATION_YAML = """
+location:
+  latitude: 50.45
+  longitude: 30.52
+  timezone: Europe/Kyiv
+rules:
+  - id: porch-motion-light
+    when:
+      device: porch-motion
+      motion: true
+    then:
+      relay: porch-light
+      state: on
+      hold_seconds: 120
+  - id: gate-motion-light
+    enabled: false
+    when:
+      device: porch-motion
+      motion: true
+    then:
+      relay: gate-light
+      state: off
+"""
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    """An app with one enabled rule, one disabled rule, and a location."""
+    sensors = tmp_path / "sensors.yaml"
+    sensors.write_text(SENSORS_YAML, encoding="utf-8")
+    automation = tmp_path / "automation.yaml"
+    automation.write_text(AUTOMATION_YAML, encoding="utf-8")
+
+    settings = build_settings(sensor_config_path=sensors, automation_config_path=automation)
+    with TestClient(create_app(settings, relay_service=build_relay_service())) as app_client:
+        yield app_client
+
+
+class TestListRules:
+    def test_every_rule_is_reported(self, client: TestClient) -> None:
+        response = client.get("/v1/automation/rules", headers=RELAY_HEADERS)
+
+        assert response.status_code == HTTPStatus.OK
+        ids = [rule["id"] for rule in response.json()["rules"]]
+        assert ids == ["porch-motion-light", "gate-motion-light"]
+
+    def test_a_disabled_rule_is_reported_as_disabled_not_omitted(self, client: TestClient) -> None:
+        rules = {
+            rule["id"]: rule
+            for rule in client.get("/v1/automation/rules", headers=RELAY_HEADERS).json()["rules"]
+        }
+
+        assert rules["porch-motion-light"]["enabled"] is True
+        assert rules["gate-motion-light"]["enabled"] is False
+
+    def test_a_rule_carries_its_trigger_and_action(self, client: TestClient) -> None:
+        rule = client.get("/v1/automation/rules", headers=RELAY_HEADERS).json()["rules"][0]
+
+        assert rule["when"] == {"device": "porch-motion", "motion": True}
+        assert rule["then"] == {"relay": "porch-light", "state": "on", "hold_seconds": 120.0}
+
+    def test_the_location_is_not_exposed(self, client: TestClient) -> None:
+        # Coordinates identify a home, and listing rules does not need them.
+        response = client.get("/v1/automation/rules", headers=RELAY_HEADERS)
+
+        assert "location" not in response.json()
+        assert "50.45" not in response.text
+
+    def test_an_empty_file_yields_an_empty_list(self, tmp_path: Path) -> None:
+        settings = build_settings(automation_config_path=tmp_path / "absent.yaml")
+        with TestClient(create_app(settings, relay_service=build_relay_service())) as client:
+            response = client.get("/v1/automation/rules", headers=RELAY_HEADERS)
+
+        assert response.json() == {"rules": []}
+
+
+class TestAuthentication:
+    def test_the_relay_key_is_required(self, client: TestClient) -> None:
+        assert client.get("/v1/automation/rules").status_code == HTTPStatus.UNAUTHORIZED
+
+    def test_the_sensor_key_is_refused(self, client: TestClient) -> None:
+        # Firmware that pushes readings has no business reading the house's wiring.
+        response = client.get("/v1/automation/rules", headers=SENSOR_HEADERS)
+
+        assert response.status_code == HTTPStatus.UNAUTHORIZED


### PR DESCRIPTION
GET /v1/automation/rules, guarded by the relay key. Read-only: rules describe a house in YAML, and editing that over HTTP is a separate decision.

The engine kept only enabled rules, so it now keeps the configured list too — otherwise the endpoint would omit a disabled rule rather than report it as disabled. The response carries no location: those coordinates identify a home and listing rules does not need them.