### PR TITLE
Reject bad automation config before the server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,10 @@ somebody else's board, and starting on it would close relays at random. So the f
 stops after `systemctl enable` and says what to edit; the run after that starts the
 service.
 
-**A bad configuration stops the service instead of looping.** The process exits 2 when
-settings do not validate, and the unit refuses to restart on that code, so the message
-naming the offending variable stays at the end of the journal rather than scrolling past
+**A bad configuration stops the service instead of looping.** Every settings variable and
+every configuration file is read before the process starts listening, and any of them
+being wrong exits 2 — a code the unit refuses to restart on. So the one line naming the
+offending variable or rule stays at the end of the journal rather than scrolling past
 every five seconds.
 
 **The sandbox is tight, and two options are deliberately missing from it.** The

--- a/src/pihome_hub/__main__.py
+++ b/src/pihome_hub/__main__.py
@@ -20,9 +20,11 @@ from typing import Final
 import uvicorn
 from pydantic import ValidationError
 
-from pihome_hub.app import build_relay_service, create_app
+from pihome_hub.app import build_relay_service, check_configuration, create_app
+from pihome_hub.automation import AutomationError
 from pihome_hub.config import Settings, get_settings
 from pihome_hub.relays import RelayError
+from pihome_hub.sensors import SensorError
 
 #: Exit code for "started with a broken configuration", following the convention
 #: that 2 means the operator got the invocation wrong.
@@ -68,14 +70,15 @@ def main() -> None:
         sys.stderr.write(render_configuration_error(exc) + "\n")
         raise SystemExit(EXIT_CONFIGURATION_ERROR) from None
 
-    # Built before the server starts so a bad relay config — or a pin this host will
-    # not give us — is reported plainly rather than as a traceback from inside a
-    # running event loop. RelayError covers both the configuration and hardware cases;
-    # catching only the former let gpiozero's own exceptions escape as a raw traceback
-    # with the wrong exit code, which a Restart=always unit turns into a crash loop.
+    # Every configuration file is read before the server starts, so a mistake in one is
+    # reported plainly rather than as a traceback from inside a running event loop.
+    # The base classes are caught, not the config-specific subclasses: catching only
+    # RelayConfigError once let gpiozero's own exceptions escape as a raw traceback
+    # with the wrong exit code, which a restarting unit turns into a crash loop.
     try:
         relay_service = build_relay_service(settings)
-    except RelayError as exc:
+        check_configuration(settings, relay_service)
+    except (RelayError, SensorError, AutomationError) as exc:
         sys.stderr.write(f"pihome-hub: {exc}\n")
         raise SystemExit(EXIT_CONFIGURATION_ERROR) from None
 

--- a/src/pihome_hub/app.py
+++ b/src/pihome_hub/app.py
@@ -62,6 +62,19 @@ def build_automation_engine(
     return AutomationEngine(relays, config.rules, sun=sun, sensors=sensors)
 
 
+def check_configuration(settings: Settings, relays: RelayService) -> None:
+    """Prove the sensor and automation files are usable before the server starts.
+
+    The engine the service runs on is built by the lifespan, inside the loop that owns
+    its timers. This builds one and throws it away, because construction is where the
+    reference checking lives and an engine that has scheduled nothing holds nothing to
+    release. The cost is reading two small YAML files twice at startup. The alternative
+    is a typo in a rule escaping as a traceback from inside uvicorn's own startup,
+    which exits 3 — a code the unit treats as worth retrying, forever.
+    """
+    build_automation_engine(settings, relays, build_sensor_store(settings))
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Acquire and release the relay service for the lifetime of the process.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import SecretStr, ValidationError
 
@@ -42,6 +44,26 @@ class TestConfigurationErrorRendering:
         assert "short" not in render_configuration_error(caught.value)
 
 
+def _configure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, automation: str) -> None:
+    """Point a runnable service at one relay and the given automation rules."""
+    (tmp_path / "relays.yaml").write_text(
+        "relays:\n  - id: porch-light\n    label: Porch light\n    pin: 17\n"
+    )
+    (tmp_path / "automation.yaml").write_text(automation)
+
+    monkeypatch.setenv("PIHOME_RELAY_API_KEY", VALID_KEY)
+    monkeypatch.setenv("PIHOME_SENSOR_API_KEY", VALID_KEY[::-1])
+    monkeypatch.setenv("PIHOME_RELAY_CONFIG_PATH", str(tmp_path / "relays.yaml"))
+    monkeypatch.setenv("PIHOME_AUTOMATION_CONFIG_PATH", str(tmp_path / "automation.yaml"))
+
+    # Reaching the server means the configuration was accepted. Failing here turns a
+    # regression into a failed test rather than a suite that hangs on a bound port.
+    monkeypatch.setattr(
+        "pihome_hub.__main__.uvicorn.run",
+        lambda *args, **kwargs: pytest.fail("the server started on a rejected configuration"),
+    )
+
+
 class TestMain:
     def test_exits_with_a_configuration_code_when_unconfigured(
         self, capsys: pytest.CaptureFixture[str]
@@ -51,3 +73,36 @@ class TestMain:
 
         assert caught.value.code == EXIT_CONFIGURATION_ERROR
         assert "PIHOME_RELAY_API_KEY" in capsys.readouterr().err
+
+    def test_a_rule_naming_something_absent_is_rejected_before_the_server_starts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Validating rules inside the lifespan exits 3, which the unit retries forever."""
+        _configure(
+            monkeypatch,
+            tmp_path,
+            "rules:\n"
+            "  - id: porch-motion-light\n"
+            "    when: {device: ghost, motion: true}\n"
+            "    then: {relay: porch-light, state: on}\n",
+        )
+
+        with pytest.raises(SystemExit) as caught:
+            main()
+
+        assert caught.value.code == EXIT_CONFIGURATION_ERROR
+        error = capsys.readouterr().err
+        assert "porch-motion-light" in error
+        assert "ghost" in error
+        assert "Traceback" not in error
+
+    def test_a_malformed_automation_file_is_rejected_before_the_server_starts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _configure(monkeypatch, tmp_path, "rules: [{id: broken}]\n")
+
+        with pytest.raises(SystemExit) as caught:
+            main()
+
+        assert caught.value.code == EXIT_CONFIGURATION_ERROR
+        assert "Traceback" not in capsys.readouterr().err


### PR DESCRIPTION
Rules were validated inside the lifespan, so a typo surfaced as a traceback from uvicorn and exited 3 — a code the unit retries every five seconds.