### PR TITLE
Document the architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ sensor fires, but only after dark. It runs on a Raspberry Pi Zero 2 W that stays
 around the clock, and it is deliberately small enough to read in one sitting.
 
 > **Status: functional and deployable.** Relay control, sensor ingestion and automation
-> all work and are covered by tests, and two files provision a Raspberry Pi — see
-> [Deployment](#deployment) and [Troubleshooting](docs/troubleshooting.md). What is still
-> missing is an architecture write-up. See [Roadmap](#roadmap).
+> all work and are covered by tests, and two files provision a Raspberry Pi. See
+> [Deployment](#deployment), [Architecture](docs/architecture.md) and
+> [Troubleshooting](docs/troubleshooting.md).
 
 ## Why this exists
 
@@ -271,7 +271,7 @@ src/pihome_hub/
     └── service.py     logical on/off/toggle over configured relays
 config/                relays.example.yaml — copy and edit; the real file is ignored
 deploy/                pihome-hub.service and install.sh — provisioning a Pi
-docs/                  troubleshooting.md — symptoms, with the messages they produce
+docs/                  architecture.md — the shape; troubleshooting.md — symptoms
 tests/                 runs without hardware, against the mock backend
 ```
 
@@ -286,9 +286,9 @@ tests/                 runs without hardware, against the mock backend
 | 5 | systemd unit, install script, deployment hardening | ✅ done |
 | 6 | Architecture, installation, migration and troubleshooting docs | in progress |
 
-Installation is covered by [Deployment](#deployment) and
-[Troubleshooting](docs/troubleshooting.md) is written. What remains in phase 6 is the
-architecture write-up and a note on moving a working installation to a new Pi.
+Installation is covered by [Deployment](#deployment), and both
+[Architecture](docs/architecture.md) and [Troubleshooting](docs/troubleshooting.md) are
+written. What remains in phase 6 is a note on moving a working installation to a new Pi.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,199 @@
+# Architecture
+
+How the pieces fit, in what order they are built, and which of them is allowed to know
+about the others. The reasoning behind individual choices is in the README's design
+notes; this describes the shape.
+
+## Shape
+
+```mermaid
+flowchart TB
+    phone["Phone / web app<br/>relay key"]
+    firmware["ESP32 sensor<br/>sensor key"]
+
+    subgraph http["api/ — the only layer that knows about HTTP"]
+        system["system.py<br/>/health"]
+        relayroutes["v1/relays.py"]
+        sensorroutes["v1/sensors.py"]
+        ruleroutes["v1/automation.py"]
+    end
+
+    guard["security.py + ratelimit.py<br/>two keys, two scopes"]
+
+    subgraph core["domain — no FastAPI, no request objects"]
+        relayservice["relays/service.py<br/>logical on/off"]
+        store["sensors/store.py<br/>latest reading per device"]
+        engine["automation/engine.py<br/>rules and hold timers"]
+    end
+
+    seam["relays/backend.py<br/><b>RelayBackend</b> protocol"]
+    mock["mock.py<br/>in memory"]
+    real["gpio.py<br/>gpiozero → /dev/gpiochip0"]
+
+    phone --> relayroutes
+    firmware --> sensorroutes
+    relayroutes -.->|depends on| guard
+    sensorroutes -.->|depends on| guard
+    ruleroutes -.->|depends on| guard
+    relayroutes --> relayservice
+    ruleroutes --> engine
+    sensorroutes --> store
+    sensorroutes --> engine
+    engine --> relayservice
+    relayservice --> seam
+    seam --> mock
+    seam --> real
+```
+
+`/health` is outside the guard: it is the one endpoint that takes no key, which is what
+makes it useful for saying whether the service is up without handing out a credential.
+
+## Layering, and the direction of every dependency
+
+Three rules, each of which holds today and is asserted by
+[`tests/test_layering.py`](../tests/test_layering.py):
+
+1. **No domain package imports FastAPI, Starlette, uvicorn, or `pihome_hub.api`.** The
+   relay, sensor and automation packages are plain Python. That is why the whole of the
+   automation engine can be tested by calling it, with no client and no event loop
+   ceremony beyond `asyncio`.
+2. **`relays` and `sensors` know nothing of each other, and nothing of `automation`.**
+   The dependency runs one way: automation reaches into both, because a rule is by
+   definition a statement about a sensor and a relay. Neither of them needs a rule to
+   exist.
+3. **Only `app.py` chooses a backend.** The route modules never import `mock` or `gpio`;
+   they receive a `RelayService` that already has one.
+
+The point of rule 1 is not tidiness. It is that the layer holding the mains wiring has no
+opinion about HTTP, so nothing about a request — a header, a status code, a JSON shape —
+can reach the code that closes a circuit.
+
+## Two kinds of configuration
+
+| Source | Holds | Read by | Shape |
+| --- | --- | --- | --- |
+| `PIHOME_*` environment / `.env` | secrets and process settings: keys, bind address, log level, which backend | `config.py`, as pydantic-settings | flat, one process |
+| YAML files | the house: relay wiring, sensor devices, automation rules | a `config.py` in each of the three domain packages | nested, per installation |
+
+The split is not stylistic. A relay's pin, polarity and startup behaviour describe a
+building and belong in a file that gets edited when someone rewires something; a bind
+address and an API key describe a process and belong in the environment, where systemd
+can hand them over without the service account ever reading them.
+
+Both are fully validated before the port is bound — see below.
+
+## Startup
+
+`__main__.main()` runs in this order, and each step can only fail in one way:
+
+1. **`get_settings()`** — pydantic validates the environment. A failure is rendered by
+   `render_configuration_error` into one block naming each offending variable, then
+   `SystemExit(2)`.
+2. **`build_relay_service(settings)`** — loads `relays.yaml`, chooses the backend, and
+   claims every pin. Catching `RelayError` here rather than a narrower subclass is
+   deliberate: gpiozero raises its own exception types, and letting one escape gave a
+   traceback with an exit code the unit retries.
+3. **`check_configuration(settings, relays)`** — loads `sensors.yaml` and
+   `automation.yaml` and builds an engine, purely to prove every rule names something
+   real. The engine is discarded; the lifespan builds the one the service runs on, inside
+   the loop that owns its timers.
+4. **`uvicorn.run(create_app(...))`** — the port is bound only now. Everything above has
+   already been read from disk, so a misconfiguration cannot surface as a traceback from
+   inside a running event loop.
+
+Exit code 2 means "everything above step 4 failed", and the unit refuses to restart on
+it. Anything the process cannot foresee — a bound port — exits 3, which is retried.
+
+## Ownership, and who closes what
+
+Ownership follows construction, because the alternative is a service whose GPIO pins get
+released underneath something still holding a reference to it.
+
+- `__main__` builds the `RelayService`, passes it to `create_app`, and closes it in a
+  `finally`.
+- The lifespan checks whether it was handed one. If it was, it does not close it; if it
+  built one itself, it does. That is the `owned` flag in `_lifespan`.
+- The `AutomationEngine` is always built by the lifespan, because it holds asyncio tasks,
+  and is always closed by it. Holds are cancelled **before** the relay service closes: a
+  revert firing against a closed service would be a confusing traceback on the way out.
+
+Both halves of that contract are pinned by `TestRelayServiceOwnership` in
+[`tests/test_review_fixes.py`](../tests/test_review_fixes.py): a supplied service survives
+the lifespan and stays usable, one the lifespan built is closed and cleared from
+`app.state`, and an app can be started twice over the same supplied service.
+
+## Three paths through the service
+
+**Reading relay state.** `GET /v1/relays` → the relay-key dependency → `RelayService`,
+which answers from the state it recorded when it last wrote a pin. It does not read the
+pin back: the level on a pin is not the logical state of a relay once polarity is in play,
+and the service is the thing that knows the mapping.
+
+**A sensor reporting.** `POST /v1/sensors/{id}/readings` with the **sensor** key →
+`SensorStore.record` → the same call hands the reading to `AutomationEngine.handle_reading`,
+which returns the ids of the rules that fired. Those ids go into the journal line, which
+is what makes "the reading arrived and matched nothing" a visible state rather than a
+guess.
+
+**A rule firing.** The engine turns the relay on or off through `RelayService` — the same
+path the HTTP route uses, not a private one — and, if the rule declares `hold_seconds`,
+schedules an asyncio task to revert. One pending revert per relay, keyed by relay id: a
+second trigger replaces the first one's timer instead of racing it, so continued motion
+keeps a light on rather than queueing a queue of reverts.
+
+## The hardware seam
+
+`RelayBackend` is a `Protocol` with four methods: `read_level`, `setup_output`, `write`,
+`close`. Two implementations satisfy it. The mock keeps a dict; the gpiozero one holds an
+`OutputDevice` per pin.
+
+Everything above the seam speaks in logical states — "the porch light is on". Only the
+backend and the `active_low` flag know that this might mean a LOW signal on the pin. The
+raw level never leaves `gpio.py`, which is why an inverted relay board is a
+one-line configuration change rather than a bug hunt.
+
+The mock is not a testing convenience bolted on afterwards; it is the default. Driving
+real pins requires `PIHOME_GPIO_BACKEND=gpiozero` and the `rpi` extra, so a host that
+cannot load the GPIO library fails loudly instead of quietly pretending to switch things.
+
+## Authentication
+
+Two keys, two scopes, compared with `secrets.compare_digest`. The relay key reads and
+controls; the sensor key may only push readings. Neither is a superset of the other,
+which is the point: firmware that reports motion cannot survey the house, and a phone
+cannot forge a motion event to reach a relay through a rule.
+
+`ratelimit.py` counts failures in buckets, and the bucket key is where the care is:
+
+| Bucket | Why it is separate |
+| --- | --- |
+| `relay:<peer>` | — |
+| `sensor:<peer>` | Sharing one bucket would let a caller holding either key clear the other's failure count on every success, so a leaked sensor key would double as a rate-limit eraser |
+| `probe:<peer>` | For the pre-dependency check below, so buggy firmware cannot exhaust the allowance protecting the relay key |
+
+`<peer>` is the connection's own address, normalised: IPv6 collapses to its `/64`, because
+a routed prefix holds ~1.8e19 addresses and counting per address would hand out a fresh
+allowance per guess. IPv4 stays per address, since those are scarce and shared behind NAT.
+`X-Forwarded-For` is deliberately ignored — trusting it without knowing the proxy would
+let any caller forge its identity.
+
+One wrinkle worth knowing about. FastAPI parses a request body **before** solving
+dependencies, so a body that is not valid JSON raises before authentication ever runs.
+That made a malformed body a route-existence oracle: 422 for a real path that takes a
+body, 404 for one that does not — usable with no key and counted by nothing. The
+`RequestValidationError` handler in `app.py` therefore re-checks authentication itself,
+using `authenticate_any_scope`: a narrower question than the route's, asking only "are you
+anonymous?", so it cannot be used to widen a scope.
+
+## What is deliberately absent
+
+- **No database.** Sensor readings are the latest per device, in memory. A restart forgets
+  them, and every device is reported as never-having-reported until it pushes again —
+  which is a truthful thing to say rather than a gap.
+- **No history.** Trends need storage, retention and a migration story; none of that
+  earns its place on a Pi Zero for switching yard lights.
+- **No users, roles or sessions.** Two static keys. This is the honest limit that blocks
+  the web client's own roadmap, and the next real piece of work here.
+- **No pin read-back.** See "Reading relay state" above.
+- **No `X-Forwarded-For`, no TLS, no LAN bind by default.** Reaching the service from
+  elsewhere is a VPN or a reverse proxy's job — see [SECURITY.md](../SECURITY.md).

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,9 +1,9 @@
 """Guards against documentation drifting away from the code it describes.
 
-A troubleshooting guide is only worth having if the messages and numbers in it are
-still the ones the service produces. Prose cannot be type-checked, so the parts that
-are machine-checkable are checked here: the paths it points at, and every constant it
-quotes at the reader as a fact.
+Documentation is only worth having if what it states is still true — a quoted error
+message, a path, a constant, the name of a test it points at as proof. Prose cannot be
+type-checked, so everything in it that is machine-checkable is checked here, and every
+document under ``docs/`` is swept without having to be listed.
 """
 
 from __future__ import annotations
@@ -17,7 +17,11 @@ from pihome_hub.__main__ import EXIT_CONFIGURATION_ERROR
 from pihome_hub.config import MIN_API_KEY_LENGTH, Settings
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-TROUBLESHOOTING = REPO_ROOT / "docs" / "troubleshooting.md"
+DOCS = REPO_ROOT / "docs"
+TROUBLESHOOTING = DOCS / "troubleshooting.md"
+
+#: Every document under docs/, so a new one is covered without being listed here.
+_DOC_NAMES = sorted(path.name for path in DOCS.glob("*.md"))
 
 
 @pytest.fixture(scope="module")
@@ -30,25 +34,45 @@ def readme() -> str:
     return (REPO_ROOT / "README.md").read_text()
 
 
-class TestTheGuideIsReachable:
-    def test_the_readme_links_to_it(self, readme: str) -> None:
-        """An unlinked guide is one nobody in trouble will find."""
-        assert "docs/troubleshooting.md" in readme
+class TestEveryDocumentIsReachable:
+    @pytest.mark.parametrize("name", _DOC_NAMES)
+    def test_the_readme_links_to_it(self, name: str, readme: str) -> None:
+        """An unlinked document is one nobody will find when they need it."""
+        assert f"docs/{name}" in readme
 
 
-class TestEveryPathItPointsAtExists:
-    def test_no_backticked_repository_path_is_stale(self, guide: str) -> None:
-        # Only paths with a directory component, and only relative ones: an absolute
-        # path in this guide is on the Pi (/etc/pihome-hub) or in /dev, not in here.
-        referenced = {
-            match
-            for match in re.findall(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+)`", guide)
+class TestEveryPathTheDocsPointAtExists:
+    @pytest.mark.parametrize("name", _DOC_NAMES)
+    def test_no_relative_link_or_backticked_path_is_stale(self, name: str) -> None:
+        text = (DOCS / name).read_text()
+
+        # Markdown links are relative to docs/; backticked paths are written from the
+        # repository root. Absolute ones live on the Pi (/etc, /dev) and are skipped.
+        links = {(DOCS / target) for target in re.findall(r"\]\((\.\.?/[^)#]+)", text)}
+        quoted = {
+            (REPO_ROOT / match)
+            for match in re.findall(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+)`", text)
             if not match.startswith("/")
         }
-        assert referenced, "path extraction found nothing — this test is out of date"
+        assert links | quoted, f"{name}: path extraction found nothing — this test is out of date"
 
-        missing = sorted(path for path in referenced if not (REPO_ROOT / path).exists())
-        assert not missing, f"the guide points at paths that do not exist: {missing}"
+        missing = sorted(str(path) for path in links | quoted if not path.exists())
+        assert not missing, f"{name} points at paths that do not exist: {missing}"
+
+
+class TestTheArchitectureNotesCiteRealTests:
+    def test_every_test_class_it_names_exists(self) -> None:
+        """Naming a guard that has been renamed away is worse than naming none."""
+        text = (DOCS / "architecture.md").read_text()
+        cited = set(re.findall(r"`(Test[A-Za-z0-9_]+)`", text))
+        assert cited, "no test class is cited — this test is out of date"
+
+        defined = {
+            name
+            for source in (REPO_ROOT / "tests").rglob("*.py")
+            for name in re.findall(r"^class (Test[A-Za-z0-9_]+)", source.read_text(), re.MULTILINE)
+        }
+        assert cited <= defined, f"cited but not defined: {sorted(cited - defined)}"
 
 
 class TestEveryNumberItQuotesIsStillTrue:

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,0 +1,88 @@
+"""The dependency rules docs/architecture.md claims the code follows.
+
+Layering is the kind of property that holds until one convenient import breaks it,
+and nothing else in a test suite notices. These read the import statements rather
+than the runtime graph, so a violation fails here at the point it is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+SOURCE_ROOT = Path(__file__).resolve().parent.parent / "src" / "pihome_hub"
+
+#: Packages holding the logic. None of them may know how requests arrive.
+_DOMAINS: Final = ("relays", "sensors", "automation")
+
+#: Everything that would make a domain package depend on being served over HTTP.
+_WEB_FRAMEWORKS: Final = ("fastapi", "starlette", "uvicorn", "pihome_hub.api")
+
+#: Which domain may import which. Automation is a statement about a sensor and a
+#: relay, so it reaches into both; neither of those needs a rule to exist.
+_ALLOWED_DOMAIN_IMPORTS: Final = {
+    "relays": frozenset(),
+    "sensors": frozenset(),
+    "automation": frozenset({"relays", "sensors"}),
+}
+
+
+def _imported_modules(source: Path) -> set[str]:
+    """Every module name the file imports, dotted and absolute."""
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    names: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None and node.level == 0:
+            names.add(node.module)
+
+    return names
+
+
+def _python_files(package: str) -> list[Path]:
+    found = sorted((SOURCE_ROOT / package).rglob("*.py"))
+    assert found, f"no source files found under {package} — this test is out of date"
+    return found
+
+
+class TestTheDomainDoesNotKnowAboutHttp:
+    @pytest.mark.parametrize("package", _DOMAINS)
+    def test_no_web_framework_is_imported(self, package: str) -> None:
+        offenders = {
+            f"{source.relative_to(SOURCE_ROOT)} -> {module}"
+            for source in _python_files(package)
+            for module in _imported_modules(source)
+            if module.startswith(_WEB_FRAMEWORKS)
+        }
+        assert not offenders, f"the domain reached for the web layer: {sorted(offenders)}"
+
+
+class TestTheDomainsStayInOneDirection:
+    @pytest.mark.parametrize("package", _DOMAINS)
+    def test_only_the_allowed_domains_are_imported(self, package: str) -> None:
+        reached = {
+            module.split(".")[1]
+            for source in _python_files(package)
+            for module in _imported_modules(source)
+            if module.startswith("pihome_hub.") and module.split(".")[1] in _DOMAINS
+        } - {package}
+
+        assert reached == _ALLOWED_DOMAIN_IMPORTS[package]
+
+
+class TestOnlyTheApplicationFactoryPicksABackend:
+    def test_no_route_module_imports_a_backend(self) -> None:
+        """A route receives a service that already has one, and cannot choose another."""
+        backends = ("pihome_hub.relays.mock", "pihome_hub.relays.gpio", "pihome_hub.relays.factory")
+        offenders = {
+            f"{source.relative_to(SOURCE_ROOT)} -> {module}"
+            for source in _python_files("api")
+            for module in _imported_modules(source)
+            if module.startswith(backends)
+        }
+        assert not offenders, f"a route module chose a backend: {sorted(offenders)}"


### PR DESCRIPTION
Adds docs/architecture.md, and a layering test asserting the three dependency rules it claims: no HTTP in the domain, one direction between domains, and only the app factory choosing a backend.