### PR TITLE
Refuse unknown keys in config files

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,7 @@ Match the line, not the exit code — they all exit 2.
 | `invalid relay configuration in …: Input should be less than or equal to 27` | A pin outside the BCM range | Use a real BCM number, not a physical pin number |
 | `pin 17 is used by both 'a' and 'b'` | Two relays on one pin | Give each its own |
 | `duplicate relay id 'a'` | Two relays share an id | Ids address relays over HTTP; they must be unique |
+| `0.active-low` then `Extra inputs are not permitted` | A misspelled or invented key. The path names it: `0` is the first entry in the list | Fix the spelling against the matching `.example.yaml`. Every config file refuses keys it does not recognise, rather than ignoring them |
 | `automation rule 'r1' triggers on device 'ghost', which is not configured. Known devices: []` | A rule names a sensor that does not exist. The known ids are listed for comparison | Fix the id in `automation.yaml`, or add the device to `sensors.yaml` |
 | `automation rule 'r1' targets relay 'gate-light', which is not configured` | Same, for the relay side | As above |
 | `automation rule 'r1' uses only_after_dark but no location is set` | Darkness needs coordinates | Add a `location` block to `automation.yaml` |
@@ -98,7 +99,7 @@ ls /dev/gpiochip*                                  # gpiochip0 is what the unit 
 | `could not claim pin 17 for relay 'porch-light': …` at startup | The pin is held by something else, the service user is not in `gpio`, or the extra is missing. The message names all three |
 | The unit starts on a Pi 5 but no pin responds | The unit's `DeviceAllow=/dev/gpiochip0` is hard-coded, and a Pi 5 numbers its chips differently. Check `ls /dev/gpiochip*` and edit the unit |
 | Every relay is inverted | `active_low` does not match the board. Active-low boards are the norm |
-| One relay is inverted and the config looks right | An unrecognised key is currently accepted in silence, so `active-low: true` reads as nothing at all. Check the spelling of every key against `config/relays.example.yaml` |
+| One relay is inverted and the config looks right | `active_low` is set per relay, not globally — check that one entry. A misspelled key cannot be the cause: unknown keys are refused at startup |
 | Relays change state while the service is stopped | Expected, and not fixable in software. A released GPIO pin returns to an input with no pull, so a stopped service leaves each relay following the board's idle level. `shutdown_state` governs only the moment before release |
 
 ## The API refuses the request

--- a/src/pihome_hub/automation/models.py
+++ b/src/pihome_hub/automation/models.py
@@ -30,7 +30,7 @@ class Location(BaseModel):
     version of this service had them written into a function body.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     latitude: Annotated[float, Field(ge=-90.0, le=90.0)]
     longitude: Annotated[float, Field(ge=-180.0, le=180.0)]

--- a/src/pihome_hub/relays/models.py
+++ b/src/pihome_hub/relays/models.py
@@ -40,7 +40,11 @@ _MAX_BCM_PIN: Final = 27
 class RelayConfig(BaseModel):
     """One controllable relay channel, as declared in ``config/relays.yaml``."""
 
-    model_config = ConfigDict(frozen=True)
+    # An unrecognised key is refused rather than ignored. Every field here has a
+    # safe-looking default or a hyphenated near-miss — ``active-low`` for
+    # ``active_low`` reads as nothing at all — and silently accepting one means
+    # running a relay at the wrong polarity with a config file that looks correct.
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     id: str = Field(min_length=1, max_length=64)
     pin: int = Field(ge=_MIN_BCM_PIN, le=_MAX_BCM_PIN)

--- a/src/pihome_hub/sensors/models.py
+++ b/src/pihome_hub/sensors/models.py
@@ -22,7 +22,7 @@ DEFAULT_STALE_AFTER_SECONDS: Final = 300.0
 class SensorDevice(BaseModel):
     """A sensor this service will accept readings from."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     id: str = Field(min_length=1, max_length=64)
     label: str = Field(min_length=1, max_length=100)

--- a/tests/relays/test_config.py
+++ b/tests/relays/test_config.py
@@ -57,3 +57,14 @@ class TestLoadRelays:
 
         with pytest.raises(RelayConfigError, match="invalid relay configuration"):
             load_relays(config_file)
+
+    def test_a_misspelled_key_is_refused_rather_than_ignored(self, tmp_path: Path) -> None:
+        """Ignoring it would run the relay at the default polarity, config looking fine."""
+        config_file = tmp_path / "relays.yaml"
+        config_file.write_text(
+            "relays:\n  - id: porch-light\n    pin: 17\n    label: x\n    active-low: false\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RelayConfigError, match="active-low"):
+            load_relays(config_file)

--- a/tests/test_input_models.py
+++ b/tests/test_input_models.py
@@ -1,0 +1,79 @@
+"""Every model that parses input outside this process must refuse unknown fields.
+
+Ignoring an unrecognised key is the quietest way to be wrong: ``active-low`` for
+``active_low`` reads as nothing at all, and the relay runs at the default polarity
+with a configuration file that looks correct. This is checked structurally rather
+than model by model, so a model added later has to make the decision explicitly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Final
+
+import pytest
+from pydantic import BaseModel
+
+import pihome_hub
+
+#: Models that only ever leave this process. Nothing external is parsed into them,
+#: so ``extra`` has nothing to guard: they are built from values already validated.
+_OUTPUT_ONLY: Final = {
+    "AutomationRuleCollection",
+    "DeviceSnapshot",
+    "HealthResponse",
+    "RelayCollection",
+    "RelayState",
+    "SensorCollection",
+}
+
+#: ``Settings`` reads the environment, where the same argument applies — a misspelled
+#: ``PIHOME_AUTH_MAX_FAILUERS`` is accepted in silence today and the hardening it was
+#: meant to apply never happens. Left as it is here because tightening it changes how
+#: every deployment's ``.env`` is read, which is a change of its own and not this one.
+_ENVIRONMENT: Final = {"Settings"}
+
+#: gpiozero lives in the optional ``rpi`` extra, so this module is not importable
+#: off a Pi. Named rather than skipped silently, so a second unimportable module
+#: fails this test instead of quietly dropping its models from the sweep.
+_NOT_IMPORTABLE: Final = {"pihome_hub.relays.gpio"}
+
+
+def _all_models() -> dict[str, type[BaseModel]]:
+    """Every pydantic model defined anywhere in the package."""
+    unimportable: set[str] = set()
+
+    for module in pkgutil.walk_packages(pihome_hub.__path__, f"{pihome_hub.__name__}."):
+        try:
+            importlib.import_module(module.name)
+        except ImportError:
+            unimportable.add(module.name)
+
+    assert unimportable == _NOT_IMPORTABLE, f"unexpected import failures: {unimportable}"
+
+    found: dict[str, type[BaseModel]] = {}
+    stack: list[type[BaseModel]] = [BaseModel]
+    while stack:
+        for subclass in stack.pop().__subclasses__():
+            if subclass.__module__.startswith(pihome_hub.__name__):
+                found[subclass.__name__] = subclass
+            stack.append(subclass)
+
+    assert found, "model discovery found nothing — this test is out of date"
+    return found
+
+
+_MODELS = _all_models()
+_EXEMPT: Final = _OUTPUT_ONLY | _ENVIRONMENT
+_INPUT_MODELS = sorted(name for name in _MODELS if name not in _EXEMPT)
+
+
+class TestUnknownFieldsAreRefused:
+    @pytest.mark.parametrize("name", _INPUT_MODELS)
+    def test_the_model_forbids_extra_fields(self, name: str) -> None:
+        assert _MODELS[name].model_config.get("extra") == "forbid"
+
+    def test_the_exemptions_all_still_exist(self) -> None:
+        """A renamed or deleted model must not leave a stale hole in the sweep."""
+        assert _MODELS.keys() >= _EXEMPT


### PR DESCRIPTION
RelayConfig, SensorDevice and Location were the three input models still ignoring them; a misspelled active-low ran the relay at the wrong polarity.