### PR TITLE
Give the service a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ beside the project. [`.env.example`](.env.example) documents each one.
 | `PIHOME_RELAY_CONFIG_PATH` | `config/relays.yaml` | Relay wiring |
 | `PIHOME_SENSOR_CONFIG_PATH` | `config/sensors.yaml` | Sensor devices (optional) |
 | `PIHOME_AUTOMATION_CONFIG_PATH` | `config/automation.yaml` | Automation rules (optional) |
+| `PIHOME_DATABASE_PATH` | `$STATE_DIRECTORY/hub.db` | Accounts. Follows the unit's `StateDirectory=`; falls back to `var/hub.db` off systemd |
 | `PIHOME_AUTH_MAX_FAILURES` | `10` | Failed auth attempts per client before 429 |
 | `PIHOME_AUTH_FAILURE_WINDOW_SECONDS` | `300` | Window those failures are counted over |
 

--- a/deploy/pihome-hub.service
+++ b/deploy/pihome-hub.service
@@ -40,9 +40,16 @@ TimeoutStopSec=20s
 
 SyslogIdentifier=pihome-hub
 
+# The one thing written at runtime: accounts and sessions. systemd creates
+# /var/lib/pihome-hub owned by User=, and punches it through ProtectSystem=strict
+# without a ReadWritePaths= exception naming a path that could then drift.
+# 0700 because the file holds password hashes and live session tokens; the default
+# 0755 would let every account on the Pi read them.
+StateDirectory=pihome-hub
+StateDirectoryMode=0700
+
 # -- Sandbox -----------------------------------------------------------------
-# Nothing is written at runtime: readings live in memory and logs go to the journal.
-# So the filesystem stays read-only, with no ReadWritePaths= exception.
+# Everything else stays read-only: readings live in memory, logs go to the journal.
 ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,14 @@ can reach the code that closes a circuit.
 | --- | --- | --- | --- |
 | `PIHOME_*` environment / `.env` | secrets and process settings: keys, bind address, log level, which backend | `config.py`, as pydantic-settings | flat, one process |
 | YAML files | the house: relay wiring, sensor devices, automation rules | a `config.py` in each of the three domain packages | nested, per installation |
+| SQLite | accounts, and what the service itself writes | `storage/` | rows, mutable at runtime |
+
+The third is the only one the service writes to, and the only one an operator does not
+edit by hand. It also decides where: `ProtectSystem=strict` leaves the filesystem
+read-only, so the unit declares `StateDirectory=pihome-hub` and systemd creates
+`/var/lib/pihome-hub` owned by the service account at mode `0700`. The database path
+defaults to the `STATE_DIRECTORY` systemd exports from that declaration, so the unit
+stays the one place the location is written down.
 
 The split is not stylistic. A relay's pin, polarity and startup behaviour describe a
 building and belong in a file that gets edited when someone rewires something; a bind
@@ -97,12 +105,21 @@ Both are fully validated before the port is bound — see below.
    `automation.yaml` and builds an engine, purely to prove every rule names something
    real. The engine is discarded; the lifespan builds the one the service runs on, inside
    the loop that owns its timers.
-4. **`uvicorn.run(create_app(...))`** — the port is bound only now. Everything above has
+4. **`prepare_database(settings.database_path)`** — opens SQLite and applies any
+   migration the file has not seen. A state directory the service cannot write to, or a
+   schema written by a newer build, stops here.
+5. **`uvicorn.run(create_app(...))`** — the port is bound only now. Everything above has
    already been read from disk, so a misconfiguration cannot surface as a traceback from
    inside a running event loop.
 
-Exit code 2 means "everything above step 4 failed", and the unit refuses to restart on
+Exit code 2 means "everything above step 5 failed", and the unit refuses to restart on
 it. Anything the process cannot foresee — a bound port — exits 3, which is retried.
+
+One subtlety worth knowing if you touch step 4: `sqlite3.connect()` opens nothing. It
+returns a handle and defers the real work, so a directory the service cannot write to
+raises on the *first statement*, not on the call. The pragmas therefore run inside the
+same block that translates errors — outside it, that arrived as a raw `OperationalError`
+and an exit code the unit retries forever.
 
 ## Ownership, and who closes what
 
@@ -187,13 +204,12 @@ anonymous?", so it cannot be used to widen a scope.
 
 ## What is deliberately absent
 
-- **No database.** Sensor readings are the latest per device, in memory. A restart forgets
-  them, and every device is reported as never-having-reported until it pushes again —
-  which is a truthful thing to say rather than a gap.
-- **No history.** Trends need storage, retention and a migration story; none of that
-  earns its place on a Pi Zero for switching yard lights.
-- **No users, roles or sessions.** Two static keys. This is the honest limit that blocks
-  the web client's own roadmap, and the next real piece of work here.
+- **No readings in the database.** There is a SQLite file now, and it holds accounts and
+  nothing else. Sensor readings stay the latest per device, in memory: a restart forgets
+  them and every device reports as never-having-reported until it pushes again, which is
+  a truthful thing to say rather than a gap.
+- **No history.** Trends need retention and a pruning story on a card with finite write
+  cycles; that does not earn its place for switching yard lights.
 - **No pin read-back.** See "Reading relay state" above.
 - **No `X-Forwarded-For`, no TLS, no LAN bind by default.** Reaching the service from
   elsewhere is a VPN or a reverse proxy's job — see [SECURITY.md](../SECURITY.md).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,8 +1,9 @@
 # Moving to another Pi
 
-A working installation is four files in `/etc/pihome-hub` and nothing else. The checkout,
-the virtualenv and the unit are all rebuilt by [`deploy/install.sh`](../deploy/install.sh)
-on the new host, so nothing about them needs to survive the move.
+A working installation is a handful of files in `/etc/pihome-hub`, plus the database in
+`/var/lib/pihome-hub`. The checkout, the virtualenv and the unit are all rebuilt by
+[`deploy/install.sh`](../deploy/install.sh) on the new host, so nothing about them needs
+to survive the move.
 
 ## What moves, and what must not
 
@@ -12,6 +13,7 @@ on the new host, so nothing about them needs to survive the move.
 | `/etc/pihome-hub/relays.yaml` | yes | The wiring. This describes the house, not the Pi |
 | `/etc/pihome-hub/sensors.yaml` | yes, **if you have one** | See the warning below |
 | `/etc/pihome-hub/automation.yaml` | yes, **if you have one** | Same |
+| `/var/lib/pihome-hub/hub.db` | yes, once there are accounts | Users and their password hashes. Leaving it behind means every account has to be created again on the new Pi |
 | `/opt/pihome-hub` | no | `git clone` it again |
 | `/opt/pihome-hub/.venv` | **never** | A virtualenv hard-codes its own path and links against the Python that built it. Copying one between hosts is how you get an interpreter that half-works |
 | `/etc/systemd/system/pihome-hub.service` | no | The installer writes it from the repository, so it can never lag behind the code |
@@ -54,7 +56,12 @@ simply fails to claim them.
 ```bash
 sudo systemctl stop pihome-hub
 sudo tar -czf ~/pihome-config.tar.gz -C /etc pihome-hub
+sudo tar -czf ~/pihome-state.tar.gz -C /var/lib pihome-hub   # once there are accounts
 ```
+
+Stopping first is not only about the relays: SQLite in WAL mode keeps `hub.db-wal`
+alongside the database, and copying the pair from a running service can capture a
+half-written transaction. A stopped service has checkpointed and removed it.
 
 Copy it across, then on the **new** Pi:
 
@@ -63,8 +70,13 @@ sudo apt install -y git python3-venv
 sudo git clone https://github.com/DGPRoman/pihome-hub.git /opt/pihome-hub
 
 sudo tar -xzf pihome-config.tar.gz -C /etc
+sudo tar -xzf pihome-state.tar.gz -C /var/lib     # if you took one
 sudo /opt/pihome-hub/deploy/install.sh
 ```
+
+If you restored a database, `chown -R pihome: /var/lib/pihome-hub` afterwards — systemd
+creates that directory for the service account, and a file unpacked as `root` inside it
+is one the service cannot write.
 
 The archive carries its own ownership and modes, and the installer repairs the directory
 anyway, so `/etc/pihome-hub` ends up `750 root:pihome` with `hub.env` at `600 root:root`
@@ -131,6 +143,7 @@ firmware and is hardest to account for.
 ```bash
 sudo systemctl disable --now pihome-hub
 sudo rm /etc/pihome-hub/hub.env
+sudo rm -rf /var/lib/pihome-hub          # password hashes
 ```
 
 Disabling matters as much as stopping: a Pi that is plugged back in later, for any reason,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,6 +57,8 @@ Match the line, not the exit code — they all exit 2.
 | `automation rule 'r1' targets relay 'gate-light', which is not configured` | Same, for the relay side | As above |
 | `automation rule 'r1' uses only_after_dark but no location is set` | Darkness needs coordinates | Add a `location` block to `automation.yaml` |
 | `PIHOME_GPIO_BACKEND=gpiozero was requested but gpiozero is not importable` | The hardware extra is not installed | `pip install '.[rpi]'` inside `/opt/pihome-hub/.venv` |
+| `could not open the database at …: attempt to write a readonly database` | The state directory is not writable by the service account | `systemctl show -p StateDirectory pihome-hub`, then check `/var/lib/pihome-hub` is owned by `pihome`. Re-running the installer repairs it |
+| `the database is at schema version 3, but this build only knows version 1` | The file was written by a newer pihome-hub — usually a downgrade, or a database restored from a Pi running a later version | Upgrade the code rather than downgrade the data: `git -C /opt/pihome-hub pull` and re-run the installer |
 
 An empty relay list is **not** an error: a hub with `relays: []` starts and serves an
 empty collection. That is a configured hub with nothing wired, which is different from a

--- a/src/pihome_hub/__main__.py
+++ b/src/pihome_hub/__main__.py
@@ -25,6 +25,7 @@ from pihome_hub.automation import AutomationError
 from pihome_hub.config import Settings, get_settings
 from pihome_hub.relays import RelayError
 from pihome_hub.sensors import SensorError
+from pihome_hub.storage import StorageError, prepare_database
 
 #: Exit code for "started with a broken configuration", following the convention
 #: that 2 means the operator got the invocation wrong.
@@ -79,6 +80,16 @@ def main() -> None:
         relay_service = build_relay_service(settings)
         check_configuration(settings, relay_service)
     except (RelayError, SensorError, AutomationError) as exc:
+        sys.stderr.write(f"pihome-hub: {exc}\n")
+        raise SystemExit(EXIT_CONFIGURATION_ERROR) from None
+
+    # Here rather than in the lifespan for the same reason as everything above: an
+    # unwritable state directory or a schema from a newer build is an operator
+    # problem, and it should read as one line rather than a traceback out of
+    # uvicorn's startup with an exit code the unit retries.
+    try:
+        prepare_database(settings.database_path)
+    except StorageError as exc:
         sys.stderr.write(f"pihome-hub: {exc}\n")
         raise SystemExit(EXIT_CONFIGURATION_ERROR) from None
 

--- a/src/pihome_hub/config.py
+++ b/src/pihome_hub/config.py
@@ -9,6 +9,7 @@ unrelated variables from the surrounding environment. Secrets are typed as
 from __future__ import annotations
 
 import ipaddress
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Final, Literal
@@ -35,6 +36,18 @@ _REJECTED_KEY_MARKERS: Final = (
     "replaceme",
     "yourkeyhere",
 )
+
+
+def _state_directory() -> Path:
+    """The writable directory systemd made for this unit, or a local stand-in.
+
+    ``STATE_DIRECTORY`` holds one entry per ``StateDirectory=`` in the unit, joined
+    by colons. This service declares one; taking the first entry keeps that true
+    rather than assuming it.
+    """
+    exported = os.environ.get("STATE_DIRECTORY", "")
+    first = exported.split(":")[0]
+    return Path(first) if first else Path("var")
 
 
 class Settings(BaseSettings):
@@ -76,6 +89,14 @@ class Settings(BaseSettings):
     #: simply not in use, not that the deployment is broken.
     sensor_config_path: Path = Path("config/sensors.yaml")
     automation_config_path: Path = Path("config/automation.yaml")
+
+    # -- State ---------------------------------------------------------------
+    #: Where accounts and sessions live. The default follows the unit rather than
+    #: repeating it: systemd exports STATE_DIRECTORY for every StateDirectory= it
+    #: created, so the one declaration in pihome-hub.service decides this on a Pi
+    #: and nothing in hub.env can drift away from it. Off systemd it falls back to
+    #: a path beside the checkout, which is what a development run wants.
+    database_path: Path = Field(default_factory=lambda: _state_directory() / "hub.db")
 
     # -- Brute-force protection ----------------------------------------------
     #: Failed authentication attempts one client may make inside the window

--- a/src/pihome_hub/storage/__init__.py
+++ b/src/pihome_hub/storage/__init__.py
@@ -1,0 +1,22 @@
+"""Persistent state: the only thing this service keeps on disk."""
+
+from __future__ import annotations
+
+from pihome_hub.storage.database import connect, prepare_database
+from pihome_hub.storage.errors import (
+    DatabaseUnavailableError,
+    SchemaTooNewError,
+    StorageError,
+)
+from pihome_hub.storage.migrations import LATEST_VERSION, current_version, migrate
+
+__all__ = [
+    "LATEST_VERSION",
+    "DatabaseUnavailableError",
+    "SchemaTooNewError",
+    "StorageError",
+    "connect",
+    "current_version",
+    "migrate",
+    "prepare_database",
+]

--- a/src/pihome_hub/storage/database.py
+++ b/src/pihome_hub/storage/database.py
@@ -1,0 +1,84 @@
+"""Opening the SQLite database, with the pragmas this service depends on.
+
+SQLite rather than a server: the whole dataset is a handful of accounts and their
+live sessions, on a Pi Zero that has no business running a database process. It is
+also the only storage in the project — readings stay in memory on purpose.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from pihome_hub.storage.errors import DatabaseUnavailableError
+from pihome_hub.storage.migrations import migrate
+
+#: How long a writer waits for another writer before giving up. Contention here is
+#: two requests logging in at once, which resolves in microseconds; the timeout is
+#: for the pathological case, so it is short enough not to hold a worker for long.
+_BUSY_TIMEOUT_MS = 5_000
+
+
+@contextmanager
+def connect(path: Path) -> Iterator[sqlite3.Connection]:
+    """Open the database at ``path``, creating its directory if need be.
+
+    Every caller gets its own connection. A single shared one would have to be
+    guarded by a lock, because FastAPI runs synchronous work in a threadpool and
+    a SQLite connection is not safe to use from several threads at once. Opening
+    is cheap, and at this traffic the cost is not worth the shared state.
+    """
+    connection: sqlite3.Connection | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Configuring inside this block, not after it: sqlite3.connect() is lazy and
+        # touches nothing, so a directory the service cannot write to raises on the
+        # first statement rather than here. Left outside, that arrives as a raw
+        # OperationalError and an exit code the unit retries.
+        connection = sqlite3.connect(path, timeout=_BUSY_TIMEOUT_MS / 1000)
+        _configure(connection)
+    except (OSError, sqlite3.Error) as exc:
+        if connection is not None:
+            connection.close()
+        msg = f"could not open the database at {path}: {exc}"
+        raise DatabaseUnavailableError(msg) from exc
+
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _configure(connection: sqlite3.Connection) -> None:
+    connection.row_factory = sqlite3.Row
+    # WAL so a read never blocks behind a write. The default rollback journal takes
+    # an exclusive lock for the duration of a write, which on an SD card is long
+    # enough to matter.
+    connection.execute("PRAGMA journal_mode = WAL")
+    # Off by default in SQLite, and per connection rather than per database, so it
+    # has to be set every time or a foreign key is decoration rather than a rule.
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+    # NORMAL rather than FULL: a power cut can lose the last transaction, which
+    # here means one session that has to be created again. FULL would fsync on
+    # every commit, and this runs on a card with finite write cycles.
+    connection.execute("PRAGMA synchronous = NORMAL")
+
+
+def prepare_database(path: Path) -> int:
+    """Open the database, bring its schema up to date, and report the version.
+
+    Called once before the server starts, so a directory the service cannot write
+    to is reported while there is still a terminal to report it on, rather than at
+    the first request that needed an account.
+    """
+    with connect(path) as connection:
+        version = migrate(connection)
+
+    # The unit's UMask=0077 already gets this right, and the state directory it is
+    # in is 0700. Set it anyway: the file holds password hashes, both of those are
+    # one edit away from being widened, and a development run has neither.
+    path.chmod(0o600)
+    return version

--- a/src/pihome_hub/storage/errors.py
+++ b/src/pihome_hub/storage/errors.py
@@ -1,0 +1,23 @@
+"""Exceptions raised by the storage layer."""
+
+from __future__ import annotations
+
+
+class StorageError(Exception):
+    """Base class for every error this package raises."""
+
+
+class DatabaseUnavailableError(StorageError):
+    """Raised when the database cannot be opened or created.
+
+    Almost always a permissions or path problem rather than a corrupt file: the
+    service runs under a sandbox with exactly one writable directory.
+    """
+
+
+class SchemaTooNewError(StorageError):
+    """Raised when the database was written by a later version of this service.
+
+    Downgrading is not supported and guessing is worse: an older build that met a
+    newer schema would read columns that mean something else now.
+    """

--- a/src/pihome_hub/storage/migrations.py
+++ b/src/pihome_hub/storage/migrations.py
@@ -1,0 +1,72 @@
+"""Schema versioning, on SQLite's own ``user_version``.
+
+No migration framework. The alternative is a dependency, a table, and a directory
+of numbered files to express what a tuple already says — for a schema that will
+hold accounts and their sessions and is not going to sprawl.
+
+Rules for anything added here: append, never edit. A migration that has run on a
+Pi is history, and rewriting it means two installations disagree about what
+version 3 was.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Final
+
+from pihome_hub.storage.errors import SchemaTooNewError
+
+#: Applied in order. The index of a statement is its version, so the first is 1.
+MIGRATIONS: Final[tuple[str, ...]] = (
+    # 1 — accounts.
+    """
+    CREATE TABLE users (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        username      TEXT    NOT NULL,
+        password_hash TEXT    NOT NULL,
+        role          TEXT    NOT NULL CHECK (role IN ('admin', 'operator', 'viewer')),
+        disabled      INTEGER NOT NULL DEFAULT 0 CHECK (disabled IN (0, 1)),
+        created_at    TEXT    NOT NULL
+    );
+    -- Case-insensitively unique: 'Roman' and 'roman' being two accounts is a
+    -- phishing affordance, not a feature.
+    CREATE UNIQUE INDEX users_username_unique ON users (username COLLATE NOCASE);
+    """,
+)
+
+#: The schema this build understands.
+LATEST_VERSION: Final = len(MIGRATIONS)
+
+
+def current_version(connection: sqlite3.Connection) -> int:
+    row = connection.execute("PRAGMA user_version").fetchone()
+    return int(row[0])
+
+
+def migrate(connection: sqlite3.Connection) -> int:
+    """Bring the database up to :data:`LATEST_VERSION`. Returns the version reached.
+
+    Raises :class:`SchemaTooNewError` if the file was written by a later build.
+    Refusing is the only safe answer: this one would read columns whose meaning it
+    does not know, and writing to them would corrupt what the newer build stored.
+    """
+    version = current_version(connection)
+
+    if version > LATEST_VERSION:
+        msg = (
+            f"the database is at schema version {version}, but this build only knows "
+            f"version {LATEST_VERSION}. It was written by a newer pihome-hub; "
+            "upgrade rather than downgrade."
+        )
+        raise SchemaTooNewError(msg)
+
+    for index in range(version, LATEST_VERSION):
+        # Each migration is one transaction, so a failure halfway leaves the
+        # database at the last version that fully applied rather than in between.
+        with connection:
+            connection.executescript(MIGRATIONS[index])
+            # No parameter binding: PRAGMA does not accept one. The value is a loop
+            # index over a tuple defined in this file, not anything from outside.
+            connection.execute(f"PRAGMA user_version = {index + 1}")
+
+    return LATEST_VERSION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,10 @@ def _isolated_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     for name in list(os.environ):
         if name.startswith("PIHOME_"):
             monkeypatch.delenv(name, raising=False)
+    # Not a PIHOME_ variable, but systemd exports it and the database path falls
+    # back to it. A developer running the suite from inside a unit would otherwise
+    # have tests writing to that unit's real state directory.
+    monkeypatch.delenv("STATE_DIRECTORY", raising=False)
     monkeypatch.chdir(tmp_path)
     # get_settings() memoises; without this a single resolution would leak into
     # every later test in the session.

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -1,0 +1,118 @@
+"""Opening the database, and the pragmas the rest of the service assumes."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pihome_hub.storage import (
+    LATEST_VERSION,
+    DatabaseUnavailableError,
+    connect,
+    prepare_database,
+)
+
+
+class TestConnect:
+    def test_creates_the_file_and_the_directory_above_it(self, tmp_path: Path) -> None:
+        """systemd makes the state directory, but a development run has no systemd."""
+        target = tmp_path / "state" / "hub.db"
+
+        with connect(target):
+            pass
+
+        assert target.exists()
+
+    def test_reports_a_directory_it_cannot_create_as_a_storage_error(self, tmp_path: Path) -> None:
+        read_only = tmp_path / "locked"
+        read_only.mkdir(mode=0o500)
+
+        with (
+            pytest.raises(DatabaseUnavailableError, match="could not open the database"),
+            connect(read_only / "sub" / "hub.db"),
+        ):
+            pass
+
+    def test_reports_an_existing_database_it_cannot_write_as_a_storage_error(
+        self, tmp_path: Path
+    ) -> None:
+        """The realistic failure, and the one that used to escape as a traceback.
+
+        ``sqlite3.connect`` opens nothing, so a read-only directory raises on the
+        first statement rather than on the call — which is why the pragmas have to
+        run inside the same block that translates the error.
+        """
+        directory = tmp_path / "state"
+        directory.mkdir()
+        target = directory / "hub.db"
+        with connect(target):
+            pass
+        directory.chmod(0o500)
+
+        try:
+            with (
+                pytest.raises(DatabaseUnavailableError, match="could not open the database"),
+                connect(target),
+            ):
+                pass
+        finally:
+            # Restored so pytest can clean the temporary directory up.
+            directory.chmod(0o700)
+
+    def test_foreign_keys_are_enforced(self, tmp_path: Path) -> None:
+        """Off by default in SQLite, and per connection — so worth pinning."""
+        with connect(tmp_path / "hub.db") as connection:
+            connection.executescript(
+                "CREATE TABLE parent (id INTEGER PRIMARY KEY);"
+                "CREATE TABLE child (parent_id INTEGER REFERENCES parent(id));"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute("INSERT INTO child (parent_id) VALUES (404)")
+
+    def test_rows_are_addressable_by_column_name(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            row = connection.execute("SELECT 1 AS answer").fetchone()
+            assert row["answer"] == 1
+
+    def test_it_runs_in_write_ahead_log_mode(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode == "wal"
+
+    def test_the_connection_is_closed_afterwards(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            pass
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            connection.execute("SELECT 1")
+
+
+class TestPrepareDatabase:
+    def test_a_fresh_file_ends_up_at_the_current_schema(self, tmp_path: Path) -> None:
+        assert prepare_database(tmp_path / "hub.db") == LATEST_VERSION
+
+    def test_the_file_is_readable_only_by_its_owner(self, tmp_path: Path) -> None:
+        """It holds password hashes, and a development run has no UMask= to lean on."""
+        target = tmp_path / "hub.db"
+        prepare_database(target)
+
+        assert target.stat().st_mode & 0o777 == 0o600
+
+    def test_running_it_twice_changes_nothing(self, tmp_path: Path) -> None:
+        """Every start calls this, so it has to be safe on an existing database."""
+        target = tmp_path / "hub.db"
+        prepare_database(target)
+
+        with connect(target) as connection:
+            connection.execute(
+                "INSERT INTO users (username, password_hash, role, created_at)"
+                " VALUES ('roman', 'x', 'admin', '2026-01-01T00:00:00Z')"
+            )
+            connection.commit()
+
+        prepare_database(target)
+
+        with connect(target) as connection:
+            assert connection.execute("SELECT count(*) FROM users").fetchone()[0] == 1

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -1,0 +1,101 @@
+"""Schema versioning: applying, resuming, and refusing to go backwards."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from pihome_hub.storage import (
+    LATEST_VERSION,
+    SchemaTooNewError,
+    connect,
+    current_version,
+    migrate,
+)
+from pihome_hub.storage.migrations import MIGRATIONS
+
+
+class TestMigrate:
+    def test_an_empty_database_starts_at_version_zero(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            assert current_version(connection) == 0
+
+    def test_it_applies_every_migration_and_records_the_version(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            assert migrate(connection) == LATEST_VERSION
+            assert current_version(connection) == LATEST_VERSION
+
+    def test_a_second_run_applies_nothing(self, tmp_path: Path) -> None:
+        with connect(tmp_path / "hub.db") as connection:
+            migrate(connection)
+            # A migration re-applied would raise "table users already exists".
+            assert migrate(connection) == LATEST_VERSION
+
+    def test_it_resumes_from_a_partially_migrated_database(self, tmp_path: Path) -> None:
+        """The case that matters once there are two: version 1 must not run again."""
+        with connect(tmp_path / "hub.db") as connection:
+            connection.executescript(MIGRATIONS[0])
+            connection.execute("PRAGMA user_version = 1")
+
+            assert migrate(connection) == LATEST_VERSION
+
+    def test_it_refuses_a_database_from_a_newer_build(self, tmp_path: Path) -> None:
+        """Downgrading would read columns whose meaning this build does not know."""
+        with connect(tmp_path / "hub.db") as connection:
+            migrate(connection)
+            connection.execute(f"PRAGMA user_version = {LATEST_VERSION + 1}")
+
+            with pytest.raises(SchemaTooNewError, match="newer pihome-hub"):
+                migrate(connection)
+
+
+class TestTheUsersTable:
+    @pytest.fixture
+    def connection(self, tmp_path: Path) -> Iterator[sqlite3.Connection]:
+        with connect(tmp_path / "hub.db") as connection:
+            migrate(connection)
+            yield connection
+
+    def _insert(self, connection: sqlite3.Connection, username: str, role: str) -> None:
+        connection.execute(
+            "INSERT INTO users (username, password_hash, role, created_at)"
+            " VALUES (?, 'hash', ?, '2026-01-01T00:00:00Z')",
+            (username, role),
+        )
+
+    def test_it_accepts_each_role(self, connection: sqlite3.Connection) -> None:
+        for index, role in enumerate(("admin", "operator", "viewer")):
+            self._insert(connection, f"user{index}", role)
+
+    def test_it_refuses_a_role_that_is_not_one_of_the_three(
+        self, connection: sqlite3.Connection
+    ) -> None:
+        """The check constraint is the backstop for a role the API layer let through."""
+        with pytest.raises(sqlite3.IntegrityError):
+            self._insert(connection, "roman", "superuser")
+
+    def test_usernames_differing_only_in_case_are_the_same_account(
+        self, connection: sqlite3.Connection
+    ) -> None:
+        """'Roman' and 'roman' as two accounts is a phishing affordance."""
+        self._insert(connection, "roman", "admin")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            self._insert(connection, "Roman", "viewer")
+
+    def test_disabled_is_a_flag_not_an_arbitrary_number(
+        self, connection: sqlite3.Connection
+    ) -> None:
+        self._insert(connection, "roman", "admin")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute("UPDATE users SET disabled = 2 WHERE username = 'roman'")
+
+
+class TestTheMigrationListIsAppendOnly:
+    def test_the_recorded_version_matches_the_number_of_migrations(self) -> None:
+        """A migration deleted rather than appended to would silently renumber the rest."""
+        assert len(MIGRATIONS) == LATEST_VERSION

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -19,6 +19,7 @@ import pytest
 
 from pihome_hub.__main__ import EXIT_CONFIGURATION_ERROR
 from pihome_hub.config import Settings
+from tests.conftest import build_settings
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 UNIT_PATH = REPO_ROOT / "deploy" / "pihome-hub.service"
@@ -66,6 +67,25 @@ class TestUnitMatchesTheCode:
         pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
         assert Path(service["ExecStart"]).name in pyproject["project"]["scripts"]
+
+
+class TestTheUnitGivesTheServiceSomewhereToWrite:
+    def test_it_declares_a_state_directory(self, service: dict[str, str]) -> None:
+        """ProtectSystem=strict leaves nothing writable without one."""
+        assert service.get("StateDirectory") == "pihome-hub"
+
+    def test_the_state_directory_is_not_world_readable(self, service: dict[str, str]) -> None:
+        """It holds password hashes and live session tokens; 0755 is the default."""
+        assert service.get("StateDirectoryMode") == "0700"
+
+    def test_the_database_default_follows_the_unit(
+        self, service: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The path is derived from STATE_DIRECTORY, which systemd exports from this."""
+        state_directory = Path("/var/lib") / service["StateDirectory"]
+        monkeypatch.setenv("STATE_DIRECTORY", str(state_directory))
+
+        assert build_settings().database_path.parent == state_directory
 
 
 class TestSandboxLeavesTheHardwareReachable:

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -15,8 +15,10 @@ import pytest
 
 SOURCE_ROOT = Path(__file__).resolve().parent.parent / "src" / "pihome_hub"
 
-#: Packages holding the logic. None of them may know how requests arrive.
-_DOMAINS: Final = ("relays", "sensors", "automation")
+#: Packages holding the logic and the state. None of them may know how requests
+#: arrive. ``storage`` is here for the same reason the three domains are: what a
+#: row means must not depend on the shape of the request that wrote it.
+_DOMAINS: Final = ("relays", "sensors", "automation", "storage")
 
 #: Everything that would make a domain package depend on being served over HTTP.
 _WEB_FRAMEWORKS: Final = ("fastapi", "starlette", "uvicorn", "pihome_hub.api")
@@ -27,6 +29,9 @@ _ALLOWED_DOMAIN_IMPORTS: Final = {
     "relays": frozenset(),
     "sensors": frozenset(),
     "automation": frozenset({"relays", "sensors"}),
+    # Storage knows about rows, not about relays. Which table a domain keeps its
+    # state in is that domain's business, and the dependency points that way.
+    "storage": frozenset(),
 }
 
 


### PR DESCRIPTION
ProtectSystem=strict left nothing writable, so the unit declares StateDirectory= and the database path follows what systemd exports from it. Schema versioning is SQLite's own user_version; no framework.